### PR TITLE
feat(NFe): implementa campos da NT 2025.002-RTC (indDoacao, gEstornoCred, gCredPresOper, gAjusteCompet)

### DIFF
--- a/DFe.Testes/Impostos/IBSCBSGeral_Teste.cs
+++ b/DFe.Testes/Impostos/IBSCBSGeral_Teste.cs
@@ -1,0 +1,146 @@
+using DFe.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado;
+using NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs;
+using NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.Tipos;
+
+namespace DFe.Testes.Impostos
+{
+    [TestClass]
+    public class IBSCBSGeral_Teste
+    {
+        [TestMethod]
+        public void DadoIBSCBSSemIndDoacaoQuandoSerializarEntaoXmlNaoDeveConterElementoIndDoacao()
+        {
+            /** 1) Preparação **/
+            var ibscbs = new IBSCBS
+            {
+                CST = CST.Cst000,
+                cClassTrib = "100010"
+            };
+
+            /** 2) Execução **/
+            var xml = FuncoesXml.ClasseParaXmlString(ibscbs);
+
+            /** 3) Verificação **/
+            Assert.IsFalse(xml.Contains("<indDoacao>"));
+        }
+
+        [TestMethod]
+        public void DadoIBSCBSComIndDoacaoQuandoSerializarEntaoXmlDeveConterElementoIndDoacao()
+        {
+            /** 1) Preparação **/
+            var ibscbs = new IBSCBS
+            {
+                CST = CST.Cst000,
+                cClassTrib = "100010",
+                indDoacao = IndDoacao.Doacao
+            };
+
+            /** 2) Execução **/
+            var xml = FuncoesXml.ClasseParaXmlString(ibscbs);
+
+            /** 3) Verificação **/
+            Assert.IsTrue(xml.Contains("<indDoacao>1</indDoacao>"));
+        }
+
+        [TestMethod]
+        public void DadoIBSCBSComGEstornoCredQuandoSerializarEntaoXmlDeveConterValoresDeEstorno()
+        {
+            /** 1) Preparação **/
+            var ibscbs = new IBSCBS
+            {
+                CST = CST.Cst410,
+                cClassTrib = "410030",
+                gEstornoCred = new gEstornoCred
+                {
+                    vIBSEstCred = 100.50m,
+                    vCBSEstCred = 50.25m
+                }
+            };
+
+            /** 2) Execução **/
+            var xml = FuncoesXml.ClasseParaXmlString(ibscbs);
+
+            /** 3) Verificação **/
+            Assert.IsTrue(xml.Contains("<vIBSEstCred>100.50</vIBSEstCred>"));
+            Assert.IsTrue(xml.Contains("<vCBSEstCred>50.25</vCBSEstCred>"));
+        }
+
+        [TestMethod]
+        public void DadoIBSCBSComGCredPresOperQuandoSerializarEntaoXmlDeveConterGrupoCredPresOper()
+        {
+            /** 1) Preparação **/
+            var ibscbs = new IBSCBS
+            {
+                CST = CST.Cst000,
+                cClassTrib = "100010",
+                gCredPresOper = new gCredPresOper
+                {
+                    vBCCredPres = 1000.00m,
+                    cCredPres = "001"
+                }
+            };
+
+            /** 2) Execução **/
+            var xml = FuncoesXml.ClasseParaXmlString(ibscbs);
+
+            /** 3) Verificação **/
+            Assert.IsTrue(xml.Contains("<gCredPresOper>"));
+            Assert.IsTrue(xml.Contains("<vBCCredPres>1000.00</vBCCredPres>"));
+        }
+
+        [TestMethod]
+        public void DadoIBSCBSComGAjusteCompetQuandoSerializarEntaoXmlDeveConterGrupoAjusteCompet()
+        {
+            /** 1) Preparação **/
+            var ibscbs = new IBSCBS
+            {
+                CST = CST.Cst810,
+                cClassTrib = "810010",
+                gAjusteCompet = new gAjusteCompet
+                {
+                    competApur = new System.DateTime(2026, 1, 1),
+                    vIBS = 200.00m,
+                    vCBS = 100.00m
+                }
+            };
+
+            /** 2) Execução **/
+            var xml = FuncoesXml.ClasseParaXmlString(ibscbs);
+
+            /** 3) Verificação **/
+            Assert.IsTrue(xml.Contains("<gAjusteCompet>"));
+            Assert.IsTrue(xml.Contains("<vIBS>200.00</vIBS>"));
+            Assert.IsTrue(xml.Contains("<vCBS>100.00</vCBS>"));
+        }
+
+        [TestMethod]
+        public void DadoIBSCBSComDoacaoEEstornoQuandoSerializarEntaoIndDoacaoDeveVirAntesDeGEstornoCred()
+        {
+            /** 1) Preparação **/
+            var ibscbs = new IBSCBS
+            {
+                CST = CST.Cst410,
+                cClassTrib = "410030",
+                indDoacao = IndDoacao.Doacao,
+                gEstornoCred = new gEstornoCred
+                {
+                    vIBSEstCred = 100.00m,
+                    vCBSEstCred = 50.00m
+                }
+            };
+
+            /** 2) Execução **/
+            var xml = FuncoesXml.ClasseParaXmlString(ibscbs);
+
+            /** 3) Verificação **/
+            var posIndDoacao = xml.IndexOf("<indDoacao>");
+            var posEstornoCred = xml.IndexOf("<gEstornoCred>");
+
+            Assert.IsTrue(posIndDoacao >= 0, "indDoacao deve estar presente no XML");
+            Assert.IsTrue(posEstornoCred >= 0, "gEstornoCred deve estar presente no XML");
+            Assert.IsTrue(posIndDoacao < posEstornoCred, "indDoacao deve vir antes de gEstornoCred no XML");
+        }
+    }
+}

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/IBSCBS.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/IBSCBS.cs
@@ -45,35 +45,61 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado
         /// </summary>
         [XmlElement(Order = 1)]
         public CST CST { get; set; }
-        
+
         /// <summary>
         ///     UB14 - Código de Classificação Tributária do IBS e CBS
         /// </summary>
         [XmlElement(Order = 2)]
         public string cClassTrib { get; set; }
-        
+
+        /// <summary>
+        ///     UB14a - Indica a natureza da operação de doação
+        /// </summary>
+        [XmlElement(Order = 3)]
+        public IndDoacao? indDoacao { get; set; }
+
+        public bool ShouldSerializeindDoacao() => indDoacao.HasValue;
+
         /// <summary>
         ///     UB15 - Grupo de Informações do IBS e da CBS
         /// </summary>
-        [XmlElement(Order = 3)]
+        [XmlElement(Order = 4)]
         public gIBSCBS gIBSCBS { get; set; }
-        
+
         /// <summary>
         ///     UB84 - Grupo de Informações do IBS e CBS em operações com imposto monofásico
         /// </summary>
-        [XmlElement(Order = 4)]
+        [XmlElement(Order = 5)]
         public gIBSCBSMono gIBSCBSMono { get; set; }
-        
+
         /// <summary>
         ///     UB106 - Transferências de Crédito
         /// </summary>
-        [XmlElement(Order = 5)]
-        public gTransfCred gTransfCred { get; set; }
-        
-        /// <summary>
-        ///     UB109 - Informações do crédito presumido de IBS para fornecimentos a partir da ZFM 
-        /// </summary>
         [XmlElement(Order = 6)]
+        public gTransfCred gTransfCred { get; set; }
+
+        /// <summary>
+        ///     UB109 - Informações do crédito presumido de IBS para fornecimentos a partir da ZFM
+        /// </summary>
+        [XmlElement(Order = 7)]
         public gCredPresIBSZFM gCredPresIBSZFM { get; set; }
+
+        /// <summary>
+        ///     UB112 - Grupo de Informações do Ajuste de Competência
+        /// </summary>
+        [XmlElement(Order = 8)]
+        public gAjusteCompet gAjusteCompet { get; set; }
+
+        /// <summary>
+        ///     UB116 - Grupo de Informações do Estorno de Crédito
+        /// </summary>
+        [XmlElement(Order = 9)]
+        public gEstornoCred gEstornoCred { get; set; }
+
+        /// <summary>
+        ///     UB120 - Grupo de Informações do Crédito Presumido da Operação
+        /// </summary>
+        [XmlElement(Order = 10)]
+        public gCredPresOper gCredPresOper { get; set; }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/Tipos/IBSCBSTipos.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/Tipos/IBSCBSTipos.cs
@@ -178,6 +178,20 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.Tipos
     }
 
     /// <summary>
+    ///     UB14a - Indica a natureza da operação de doação.
+    ///     <para>1 - Operação de doação</para>
+    /// </summary>
+    public enum IndDoacao
+    {
+        /// <summary>
+        ///     1 - Operação de doação
+        /// </summary>
+        [Description("Operação de doação")]
+        [XmlEnum("1")]
+        Doacao = 1
+    }
+
+    /// <summary>
     ///     <para>0 - Sem Crédito Presumido</para>
     ///     <para>1 - Bens de consumo final (55%)</para>
     ///     <para>2 - Bens de capital (75%)</para>


### PR DESCRIPTION
## Contexto

Adequação do modelo `IBSCBS` (grupo UB12) às exigências da **Nota Técnica 2025.002-RTC** da SEFAZ, que adapta os layouts da NF-e (modelo 55) e NFC-e (modelo 65) à **Reforma Tributária do Consumo (IBS/CBS/IS)**, conforme a Emenda Constitucional 132/2023 e a Lei Complementar 214/2025.

Durante a análise do codebase, identificamos que:
- O campo `indDoacao` (indicador de doação) **não existia** no projeto
- As classes `gEstornoCred`, `gCredPresOper` e `gAjusteCompet` já existiam como arquivos, mas **não eram referenciadas** pela classe pai `IBSCBS`, ficando inacessíveis na serialização XML

---

## O que mudou

### Novo campo: `indDoacao` (ID UB14a)

- **Tipo:** Enum nullable (`IndDoacao?`), serializado como `<indDoacao>1</indDoacao>`
- **Ocorrência:** 0-1 (opcional) — omitido do XML quando não informado via `ShouldSerialize`
- **Uso:** Indica que a operação é uma doação, orientando a apuração e geração de débitos ou estornos de IBS e CBS conforme o cenário tributário
- **Enum criado em:** `NFe.Classes/.../Tipos/IBSCBSTipos.cs`

### Grupos existentes agora referenciados na classe `IBSCBS`

| ID | Grupo | Descrição | Conteúdo principal |
|----|-------|-----------|--------------------|
| UB116 | `gEstornoCred` | Grupo de Informações do Estorno de Crédito | `vIBSEstCred`, `vCBSEstCred` — valores de IBS/CBS a estornar. Obrigatório quando o bem não gera débito futuro (ex: roubo, perda), vinculado ao `cClassTrib 410030` |
| UB120 | `gCredPresOper` | Grupo de Informações do Crédito Presumido da Operação | `vBCCredPres`, `cCredPres`, `gIBSCredPres`, `gCBSCredPres` |
| UB112 | `gAjusteCompet` | Grupo de Informações do Ajuste de Competência | `competApur` (AAAA-MM), `vIBS`, `vCBS` |

### Ordem XML atualizada

A ordem dos `[XmlElement(Order = N)]` foi ajustada para respeitar a sequência definida na NT 2025.002-RTC:

| Order | ID | Campo | Status |
|-------|----|-------|--------|
| 1 | UB13 | CST | já existia |
| 2 | UB14 | cClassTrib | já existia |
| 3 | UB14a | indDoacao | **NOVO** |
| 4 | UB15 | gIBSCBS | reordenado |
| 5 | UB84 | gIBSCBSMono | reordenado |
| 6 | UB106 | gTransfCred | reordenado |
| 7 | UB109 | gCredPresIBSZFM | reordenado |
| 8 | UB112 | gAjusteCompet | **NOVO ref.** |
| 9 | UB116 | gEstornoCred | **NOVO ref.** |
| 10 | UB120 | gCredPresOper | **NOVO ref.** |

---

## Impacto para consumidores do pacote NuGet

- **Não há breaking changes.** Todos os campos novos são opcionais (nullable ou referência null). Código existente que já utiliza `IBSCBS` continua funcionando sem alteração.
- Para utilizar os novos campos, basta atribuir valores às novas propriedades (`indDoacao`, `gEstornoCred`, `gCredPresOper`, `gAjusteCompet`).
- A serialização XML continua compatível com schemas anteriores quando os campos não são preenchidos.

### Exemplo de uso

```csharp
// Operação de doação com estorno de crédito
var ibscbs = new IBSCBS
{
    CST = CST.Cst410,
    cClassTrib = "410030",
    indDoacao = IndDoacao.Doacao,
    gEstornoCred = new gEstornoCred
    {
        vIBSEstCred = 100.50m,
        vCBSEstCred = 50.25m
    }
};
```

---

## Arquivos alterados

| Arquivo | Alteração |
|---------|-----------|
| `NFe.Classes/.../Compartilhado/IBSCBS.cs` | Adiciona `indDoacao` e referências a `gEstornoCred`, `gCredPresOper`, `gAjusteCompet`; reordena `XmlElement(Order)` |
| `NFe.Classes/.../Compartilhado/Tipos/IBSCBSTipos.cs` | Adiciona enum `IndDoacao` |
| `DFe.Testes/Impostos/IBSCBSGeral_Teste.cs` | 6 testes de serialização XML |
| `CLAUDE.md` | Guia de navegação do projeto para o Claude Code |
| `docs/README.md` | Índice da pasta de documentação |

---

## Testes

6 testes unitários de serialização XML adicionados em `IBSCBSGeral_Teste.cs`:

- [x] `indDoacao` omitido do XML quando não informado
- [x] `indDoacao` serializado como `<indDoacao>1</indDoacao>` quando informado
- [x] `gEstornoCred` serializa `vIBSEstCred` e `vCBSEstCred` corretamente
- [x] `gCredPresOper` serializa grupo com `vBCCredPres`
- [x] `gAjusteCompet` serializa grupo com `competApur`, `vIBS`, `vCBS`
- [x] Ordem XML: `indDoacao` vem antes de `gEstornoCred`

---

## Referências

- [NT 2025.002-RTC (Portal Nacional da NF-e)](https://www.nfe.fazenda.gov.br/portal/listaConteudo.aspx?tipoConteudo=04BIflQt1aY%3D)
- Lei Complementar 214/2025
- Emenda Constitucional 132/2023

https://claude.ai/code/session_0162NGe8bRmzkimNiGyE7wD5