### PR TITLE
fix(NFe): adiciona CST 515 (Diferimento com redução de alíquota) ao e…

### DIFF
--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/Tipos/IBSCBSTipos.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/Tipos/IBSCBSTipos.cs
@@ -48,6 +48,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.Tipos
     ///     <para>400 - Isenção</para>
     ///     <para>410 - Imunidade e não incidência</para>
     ///     <para>510 - Diferimento</para>
+    ///     <para>515 - Diferimento com redução de alíquota</para>
     ///     <para>550 - Suspensão</para>
     ///     <para>620 - Tributação Monofásica</para>
     ///     <para>800 - Transferência de crédito</para>
@@ -133,7 +134,14 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.Tipos
         [Description("Diferimento")]
         [XmlEnum("510")]
         Cst510,
-        
+
+        /// <summary>
+        ///     515 - Diferimento com redução de alíquota
+        /// </summary>
+        [Description("Diferimento com redução de alíquota")]
+        [XmlEnum("515")]
+        Cst515,
+
         /// <summary>
         ///     550 - Suspensão
         /// </summary>


### PR DESCRIPTION
…num IBS/CBS

O enum CST em NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/Tipos/IBSCBSTipos.cs não contemplava o valor 515, introduzido pela NT 2025.002 (Reforma Tributária do Consumo) como par do CST 510 para casos de diferimento com redução de alíquota — uso comum em operações com insumos agropecuários e aquícolas previstas na LC 214/2025.

Como consequência, XMLs autorizados pela SEFAZ contendo <IBSCBS><CST>515</CST></IBSCBS> falhavam na desserialização via XmlSerializer (Instance validation error: '515' is not a valid value), impedindo o import da nota no consumidor da biblioteca.

Foi adicionado o membro Cst515 com [XmlEnum("515")] e [Description("Diferimento com redução de alíquota")], mantendo a ordem numérica entre Cst510 e Cst550 e seguindo o mesmo padrão dos demais membros do enum. O resumo no XML doc da tipo CST também foi atualizado.

Referência: tabela TCstIbsCbs publicada no DFe-Portal SVRS e Informe Técnico 2025.002 v1.50 (Tabelas CST IBS/CBS).